### PR TITLE
Add support for `Rational{Int}` and `BigFloat`

### DIFF
--- a/src/QFM_n-dim.jl
+++ b/src/QFM_n-dim.jl
@@ -22,7 +22,7 @@ julia> ps = [@SVector rand(2) for _ in 1:6]
  [0.6611433726193705, 0.6394313620423493]
 
 julia> quadratic_fitting(vcat(ps, ps), vcat(q.(ps).-1, q.(ps).+1))
-Quadratic{2, 3, Float64}([1.9999999998835847, 1.000000000003638, 3.0], [0.9999999999417923, 2.0], 1.999999999985448)
+Quadratic{2, 3, Float64}([2.000000000387182, 0.9999999999890256, 2.999999999972893], [0.9999999997884512, 2.0000000000207985], 2.000000000052808)
 ```
 """
 function quadratic_fitting(ps::AbstractVector{<:StaticVector{D, T}}, fs::AbstractVector{T}) where {D, T<:Real}

--- a/src/QFM_n-dim.jl
+++ b/src/QFM_n-dim.jl
@@ -25,13 +25,14 @@ julia> quadratic_fitting(vcat(ps, ps), vcat(q.(ps).-1, q.(ps).+1))
 Quadratic{2, 3, Float64}([1.9999999998835847, 1.000000000003638, 3.0], [0.9999999999417923, 2.0], 1.999999999985448)
 ```
 """
-function quadratic_fitting(ps::AbstractVector{<:StaticVector{D, <:Real}}, fs::AbstractVector{<:Real}) where D
+function quadratic_fitting(ps::AbstractVector{<:StaticVector{D, T}}, fs::AbstractVector{T}) where {D, T<:Real}
     L = D*(D+1)÷2
     M = D+L+1
     N = length(ps)
+    U = StaticArrays.arithmetic_closure(T)
     length(fs) == N ≥ M || error("The length of initial values should be larger than $(M).")
-    X = ones(M, N)
-    F = zeros(N)
+    X = ones(U, M, N)
+    F = zeros(U, N)
     _initialize_XF!(X, F, ps, fs)
     _update_XF_at_j!(X, F, ps, fs, mod(length(ps), 1:N))
     return _quadratic(X, F, Val(D))
@@ -83,13 +84,14 @@ julia> fs = f.(ps);
 julia> optimize_qfm!(f, ps, fs, 20);
 ```
 """
-function optimize_qfm!(f, ps::Vector{<:SVector{D, <:Real}}, fs::Vector{<:Real}, n::Integer) where D
+function optimize_qfm!(f, ps::Vector{<:SVector{D, T}}, fs::Vector{T}, n::Integer) where {D, T<:Real}
     L = D*(D+1)÷2
     M = D+L+1
     N = length(ps)
+    U = StaticArrays.arithmetic_closure(T)
     length(fs) == N ≥ M || error("The length of initial values should be larger than $(M).")
-    X = ones(M, N)
-    F = zeros(N)
+    X = ones(U, M, N)
+    F = zeros(U, N)
     _initialize_XF!(X, F, ps, fs)
     for _ in 1:n
         _update_XF_at_j!(X, F, ps, fs, mod(length(ps), 1:N))

--- a/src/QIM_1-dim.jl
+++ b/src/QIM_1-dim.jl
@@ -1,4 +1,4 @@
-function _recursion_qim!(xs::Vector{<:Real}, fs::Vector{<:Real}, F::MVector{3}, X::MVector{3})
+function _recursion_qim!(xs::Vector{<:Real}, fs::Vector{<:Real}, F::StaticVector{3}, X::StaticVector{3})
     F[mod(length(xs), 1:3)] = fs[end]
     X[mod(length(xs), 1:3)] = xs[end]
     f₁ ,f₂, f₃ = F
@@ -44,10 +44,11 @@ julia> fs = f.(xs);
 julia> optimize_qim!(f, xs, fs, 20);
 ```
 """
-function optimize_qim!(f, xs::Vector{<:Real}, fs::Vector{<:Real}, n::Integer)
+function optimize_qim!(f, xs::Vector{T}, fs::Vector{T}, n::Integer) where {T <: Real}
     length(xs) ≠ 3 && error("The length of initial values should be 3.")
-    F = @MVector zeros(3)
-    X = @MVector zeros(3)
+    U = StaticArrays.arithmetic_closure(T)
+    F = SizedVector{3}(zeros(U, 3))
+    X = SizedVector{3}(zeros(U, 3))
     X[1] = xs[1]
     X[2] = xs[2]
     F[1] = f(xs[1])

--- a/src/QIM_n-dim.jl
+++ b/src/QIM_n-dim.jl
@@ -22,7 +22,7 @@ julia> ps = [@SVector rand(2) for _ in 1:6]
  [0.6611433726193705, 0.6394313620423493]
 
 julia> quadratic_interpolation(ps, q.(ps))
-Quadratic{2, 3, Float64}([1.9999999999995772, 1.0000000000000466, 2.9999999999999947], [1.000000000000042, 1.9999999999999858], 1.9999999999999585)
+Quadratic{2, 3, Float64}([1.9999999999997884, 0.999999999999996, 2.999999999999987], [1.0000000000001212, 2.0000000000000053], 1.999999999999966)
 ```
 """
 function quadratic_interpolation(ps::AbstractVector{<:StaticVector{D, T}}, fs::AbstractVector{T}) where {D, T<:Real}
@@ -173,7 +173,7 @@ julia> ps_init = [@SVector rand(2) for _ in 1:6]
  [0.4570310908017041, 0.2993652953937611]
  [0.6611433726193705, 0.6394313620423493]
 
-julia> ps, fs = optimize_qfm(f, ps_init, 20);
+julia> ps, fs = optimize_qfm(f, ps_init, 10);
 ```
 """
 function optimize_qim(f, ps_init::Vector{<:SVector{D, <:Real}}, n::Integer) where D

--- a/src/QIM_n-dim.jl
+++ b/src/QIM_n-dim.jl
@@ -25,13 +25,14 @@ julia> quadratic_interpolation(ps, q.(ps))
 Quadratic{2, 3, Float64}([1.9999999999995772, 1.0000000000000466, 2.9999999999999947], [1.000000000000042, 1.9999999999999858], 1.9999999999999585)
 ```
 """
-function quadratic_interpolation(ps::AbstractVector{<:StaticVector{D, <:Real}}, fs::AbstractVector{<:Real}) where D
+function quadratic_interpolation(ps::AbstractVector{<:StaticVector{D, T}}, fs::AbstractVector{T}) where {D, T<:Real}
     L = D*(D+1)÷2
     M = D+L+1
     N = length(ps)
+    U = StaticArrays.arithmetic_closure(T)
     length(fs) == N == M || error("The length of initial values should be equal to $(M).")
-    X = @MMatrix ones(M, M)
-    F = @MVector zeros(M)
+    X = SizedMatrix{M,M}(ones(U, M, M))
+    F = SizedVector{M}(zeros(U, M))
     _initialize_XF!(X, F, ps, fs)
     _update_XF_at_j!(X, F, ps, fs, mod(length(ps), 1:M))
     return _quadratic(X, F, Val(D))
@@ -79,13 +80,14 @@ julia> fs = f.(ps);
 julia> optimize_qim!(f, ps, fs, 20);
 ```
 """
-function optimize_qim!(f, ps::Vector{<:SVector{D, <:Real}}, fs::Vector{<:Real}, n::Integer) where D
+function optimize_qim!(f, ps::Vector{<:SVector{D, T}}, fs::Vector{T}, n::Integer) where {D, T<:Real}
     L = D*(D+1)÷2
     M = D+L+1
     N = length(ps)
+    U = StaticArrays.arithmetic_closure(T)
     length(fs) == N == M || error("The length of initial values should be equal to $(M).")
-    X = @MMatrix ones(M, M)
-    F = @MVector zeros(M)
+    X = SizedMatrix{M,M}(ones(U, M, M))
+    F = SizedVector{M}(zeros(U, M))
     _initialize_XF!(X, F, ps, fs)
     for _ in 1:n
         _update_XF_at_j!(X, F, ps, fs, mod(length(ps), 1:M))

--- a/src/quadratic.jl
+++ b/src/quadratic.jl
@@ -124,7 +124,7 @@ end
 
 function _quadratic(X::StaticMatrix{N,N}, F::StaticVector{N}, ::Val{D}) where {N, D}
     L = D*(D+1)÷2
-    Y = pinv(X') * F
+    Y = X' \ F
     a = Y[SOneTo(L)]
     b = SVector{D}(Y[L+1:L+D])
     c = Y[end]
@@ -133,7 +133,7 @@ end
 
 function _quadratic(X::AbstractMatrix, F::AbstractVector, ::Val{D}) where {D}
     L = D*(D+1)÷2
-    Y = pinv(X*X')*(X*F)
+    Y = (X*X')\(X*F)
     a = Y[SOneTo(L)]
     b = SVector{D}(Y[L+1:L+D])
     c = Y[end]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -150,8 +150,8 @@ end
     @testset "D = 2" begin
         Random.seed!(42)
         ps_init = [@SVector rand(2) for _ in 1:10]
-        ps, fs = optimize_qfm(f2, ps_init, 30)
-        @test length(ps) == 40
+        ps, fs = optimize_qfm(f2, ps_init, 20)
+        @test length(ps) == 30
         @test norm(ForwardDiff.gradient(f2, ps[end])) < 2e-3
         @test norm(ForwardDiff.gradient(f2, ps[1])) > 1e-1
         @test minimum(norm.(ForwardDiff.gradient.(f2, ps))) < 2e-4

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -188,3 +188,31 @@ end
     @test norm((quadratic_fitting(ps, fs) - q2).b) < 1e-3
     @test norm((quadratic_fitting(ps, fs) - q2).c) < 1e-3
 end
+
+@testset "more precision types" begin
+    @testset "Rational" begin
+        f(p) = p[1]^3 - p[1]
+        xs_init = big.([0//1, 1//2, 2//3])
+        ps_init = SVector.(xs_init)
+        xs, fxs = optimize_qim(f, xs_init, f.(xs_init), 10)
+        ps, fps = optimize_qim(f, ps_init, f.(ps_init), 10)
+        @test fxs isa Vector{Rational{BigInt}}
+        @test fps isa Vector{Rational{BigInt}}
+        @test fxs == fps
+        @test SVector.(xs) == ps
+        @test 1-3xs[end]^2 < 1e-30
+    end
+
+    @testset "BigFloat" begin
+        f(p) = p[1]^3 - p[1]
+        xs_init = big.([0/1, 1/2, 2/3])
+        ps_init = SVector.(xs_init)
+        xs, fxs = optimize_qim(f, xs_init, f.(xs_init), 10)
+        ps, fps = optimize_qim(f, ps_init, f.(ps_init), 10)
+        @test fxs isa Vector{BigFloat}
+        @test fps isa Vector{BigFloat}
+        @test fxs ≈ fps
+        @test SVector.(xs) ≈ ps
+        @test 1-3xs[end]^2 < 1e-30
+    end
+end


### PR DESCRIPTION
```julia
julia> using Plots, QuadraticOptimizer

julia> f(p) = p[1]^3 - p[1]
f (generic function with 1 method)

julia> xs_init = big.([0//1,1//2,2//3])
3-element Vector{Rational{BigInt}}:
  0
 1//2
 2//3

julia> xs, fs = optimize_qim(f, xs_init, f.(xs_init), 10)
(Rational{BigInt}[0, 1//2, 2//3, 4//7, 42//73, 3209//5560, 942619//1632653, 1323642393637//2292615444202, 41618148026394332904831//72084746926297506569588, 179878072848792328358029958567603475305687//311557961341618210294790311309079244837532, 5720987027765781398829234092990781092027967240006253050580601775270910576589//9909040201532792815007791439551646782016213103745320113927131840196287618832, 4636311256544736228324689881024734784452981689990160348638807495700619919316563414557346201070842090033167408178428636668296207728681730203//8030326656038986615446027447713207055480026614992615709923845351879193241997222058352483222881516560346157345508988609450294233193452189845, 49583097177930544682994558190605283123967176781366839624861225208056213838458006285423403527601106683097208260814418000855425981330828234839932907835451740493665523307519921541587599037685565062199197077613302127820639517130035491725679643779872633224722811//85880443508800720635419774498989945524564438816508566318017396283151828343904859548352214565222956079899905508005769825116606658215213211750632823395161005723268824728146808141230414411502874345175171517170951677464044221817018349096820375984539668696726424], Rational{BigInt}[0, -3//8, -10//27, -132//343, -149730//389017, -66156484071//171879616000, -1675057753994710512//4351927703592909077, -4638117585857900181043281742119350295//12050182965277525019804886210155170408, -144171111875233770127078564207999898701088797742255071260145390265073//374567536127402410268753051627821083029979015330903812973049184305472, -11640313413701267779351394692241128865666847206162413719102067201997032010348912086447997248503851039468332750601837546095785//30242421372834173557119434271906673805629991891421953585394182046523868971483265942270923488249515224257570239502709515832768, -374492293252796011901386642664187482213641772097410898791316344662212139347037366007345446838245636943736342350912909105986410658294739998367168719006939660901846393413643740411829568032503969108649456129578162083025288002247467//972959518435239224479073533163272295441370680033278572161536095279820221469757582312428722161883340220925483023186707169550629878382971508373618558150763383314336621996817443670646678376575935782703384245730244529062387127226368, -199318563687148401524205275766955894067118195878308233255585261341692540525406739561364625227209214402057791608615339284473103092439027319302046949325531430900190545324355934146139160361823866180252952071444234823688516612844576602864914605677043823941122442574125174157434105260335209841811304915666812817516724502834155146503848361488039758401029965300852229331180711998008648364028576875226917125393627131208351648//517844818796691134173324060027758177304472822447890737539321874055742624300672422314431823231703047279902099205989189664230335952689200366662536194445196758380610566541983548994748501466384305765769866229597624351471376168741235729912242537032936947408032723750914542094460653647477757644621973920659780309313316310462187637608440738622057678131313547989450392184094335129713728268979285646953334814231531880090526125, -243798455135812426080470181445167509796988260195527911102684423257812300269356912096794830975217535915357915146938270018660413602256870966946239992579903584141404171651239605088221640078054343196430602527003251085051813980837487156950103733234006812750072474544423254625174880135741613516503824603520120224975151647042890232804810359040182595262079485335166614091874407737862711215837175109252434966315925620319334531644157670051776699059834817374047129802818510829358643942933121269696598930654304779727205295729657877658116260618163102172331508636446665860721991882599145288363453766663228839959788719873510548396718635431030581414137250309837768159905034733980824931017702738059342558807225298142921149269631955037556679017728579308260682690624405298352766965597500605//633406966653042918775709622363190668505244039393006007610794658201017978314906886627777585032464117727492299711751285128572844623612411433282006539417921579286987015455288205285371250046940199547660269031752410697043436293507200039404394636265136124788611611792421730445234416127830979885339495283288710028826503448410441262181142094339633917704796466809113726619637175637081375544154129658518858763412066551909815814197480556329879032905777585379064180394112021997700362465729207441774637692212959302504557750292477276231249320298489339050277904181809068946646997164252606949033092704891015783472238877931708467306542709539749920922431711679719551731081093253956681178884919261205101966852879060539759062717032999358189121812184799582041680467569505495949671508588353024])

julia> plot(abs.(1 .- 3 * xs .^ 2); yscale=:log10, yticks=[10.0^i for i in -40:5:0])
```

![image](https://github.com/user-attachments/assets/57b223d4-b3c2-4cdb-8877-09c72dee9dfb)
